### PR TITLE
Adding AWS CLI Profile switch and mechanism to authorize additional IAM Roles into system:masters

### DIFF
--- a/EksCreationEngine.py
+++ b/EksCreationEngine.py
@@ -1288,8 +1288,10 @@ class ClusterManager():
         # If additional principals are required to be authorized, attempt to do so
         if addtl_auth_principals:
             for arn in addtl_auth_principals:
+                # Split out the name part of the Role
+                addtlRoleName = str(arn.split('/')[1])
                 # Create a patch object to add into
-                newAuthZScript=f'''ROLE="    - rolearn: {arn}\\n      username: emr-containers\\n      groups:\\n        - system:masters"
+                newAuthZScript=f'''ROLE="    - rolearn: {arn}\\n      username: {addtlRoleName}\\n      groups:\\n        - system:masters"
                 kubectl get -n kube-system configmap/aws-auth -o yaml | awk "/mapRoles: \|/{{print;print \\"$ROLE\\";next}}1" > /tmp/aws-auth-patch.yml
                 kubectl patch configmap/aws-auth -n kube-system --patch "$(cat /tmp/aws-auth-patch.yml)"
                 '''

--- a/EksCreationEngine.py
+++ b/EksCreationEngine.py
@@ -261,10 +261,12 @@ class ClusterManager():
         createdAt = str(datetime.utcnow())
 
         # Static list of required AWS Managed Policies for EKS Managed Nodegroup Roles
+        # Adding SSM for SSM access as SSH Keypairs are not specified
         nodegroupAwsManagedPolicies = [
             'arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy',
             'arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly',
-            'arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy'
+            'arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy',
+            'arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore'
         ]
 
         # Grab S3 Node Group policy from other Function & add to List if MDE is enabled
@@ -433,6 +435,12 @@ class ClusterManager():
                             {
                                 'Key': 'CreatedWith',
                                 'Value': 'Lightspin ECE'
+                            },
+                            # This tag is required per AWS Docs
+                            # One, and only one, of the security groups associated to your nodes should have the following tag applied: For more information about tagging, see Working with tags using the console. kubernetes.io/cluster/cluster-name: owned
+                            {
+                                'Key': f'kubernetes.io/cluster/{cluster_name}',
+                                'Value': 'owned'
                             }
                         ]
                     }
@@ -775,7 +783,8 @@ class ClusterManager():
                 },
                 logging={
                     'clusterLogging': [
-                        {
+                        {   
+                            # all Logging types are enabled here
                             'types': ['api','audit','authenticator','controllerManager','scheduler'],
                             'enabled': True
                         }
@@ -879,7 +888,7 @@ class ClusterManager():
                 mdatp threat policy set --type potentially_unwanted_application --action block
                 mdatp config network-protection enforcement-level --value block
                 mdatp config real-time-protection --value enabled
-                TOKEN=`curl -X PUT 'http://169.254.169.254/latest/api/token' -H 'X-aws-ec2-metadata-token-ttl-seconds: 21600'`
+                TOKEN=$(curl -X PUT 'http://169.254.169.254/latest/api/token' -H 'X-aws-ec2-metadata-token-ttl-seconds: 21600')
                 INSTANCE_ID=$(curl -H 'X-aws-ec2-metadata-token: $TOKEN' -v http://169.254.169.254/latest/meta-data/instance-id)
                 mdatp edr tag set --name GROUP --value $INSTANCE_ID
                 '''
@@ -900,7 +909,7 @@ class ClusterManager():
                 mdatp threat policy set --type potentially_unwanted_application --action block
                 mdatp config network-protection enforcement-level --value block
                 mdatp config real-time-protection --value enabled
-                TOKEN=`curl -X PUT 'http://169.254.169.254/latest/api/token' -H 'X-aws-ec2-metadata-token-ttl-seconds: 21600'`
+                TOKEN=$(curl -X PUT 'http://169.254.169.254/latest/api/token' -H 'X-aws-ec2-metadata-token-ttl-seconds: 21600')
                 INSTANCE_ID=$(curl -H 'X-aws-ec2-metadata-token: $TOKEN' -v http://169.254.169.254/latest/meta-data/instance-id)
                 mdatp edr tag set --name GROUP --value $INSTANCE_ID
                 '''
@@ -1042,7 +1051,7 @@ class ClusterManager():
 
         return launchTemplateId
     
-    def builder(kubernetes_version, bucket_name, ebs_volume_size, ami_id, instance_type, cluster_name, cluster_role_name, nodegroup_name, nodegroup_role_name, launch_template_name, vpc_id, subnet_ids, node_count, mde_on_nodes, additional_ports, falco_bool, falco_sidekick_destination_type, falco_sidekick_destination, ami_os, ami_architecture, datadog_api_key, datadog_bool):
+    def builder(kubernetes_version, bucket_name, ebs_volume_size, ami_id, instance_type, cluster_name, cluster_role_name, nodegroup_name, nodegroup_role_name, launch_template_name, vpc_id, subnet_ids, node_count, mde_on_nodes, additional_ports, falco_bool, falco_sidekick_destination_type, falco_sidekick_destination, ami_os, ami_architecture, datadog_api_key, datadog_bool, addtl_auth_principals):
         '''
         This function is the 'brain' that controls creation and calls the required functions to build infrastructure and services (EKS, EC2, IAM).
         This function also stores all required arguments into cache to facilitate rollbacks upon errors
@@ -1219,6 +1228,8 @@ class ClusterManager():
         # Passes various arguements to the `create_launch_template` which returns a Launch Template ID (of the latest version) to pass to the Nodegroup creation payload
         launchTemplateId = ClusterManager.create_launch_template(cluster_name, kubernetes_version, ami_id, bucket_name, launch_template_name, kms_key_arn, securityGroupId, ebs_volume_size, instance_type, mde_on_nodes, ami_os, ami_architecture)
 
+        print(f'Creating Nodegroup {nodegroup_name} for Cluster {clusterName}')
+
         # Create and launch the Nodegroup
         try:
             eks.create_nodegroup(
@@ -1263,23 +1274,35 @@ class ClusterManager():
             print(f'Error encountered: {we}')
             RollbackManager.rollback_from_cache(cache=cache)
 
-        print(f'Creation complete. Nodegroup {nodegroup_name} in Cluster {cluster_name} is online')
+        print(f'Creation complete. Nodegroup {nodegroup_name} in Cluster {clusterName} is online')
 
         # Retrieve region for AWS CLI kubectl generation
         session = boto3.session.Session()
         awsRegion = session.region_name
 
         # Setup first time cluster connection with AWS CLI
-        updateKubeconfigCmd = f'aws eks update-kubeconfig --region {awsRegion} --name {cluster_name}'
+        updateKubeconfigCmd = f'aws eks update-kubeconfig --region {awsRegion} --name {clusterName}'
         updateKubeconfigProc = subprocess.run(updateKubeconfigCmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         print(updateKubeconfigProc.stdout.decode('utf-8'))
+
+        # If additional principals are required to be authorized, attempt to do so
+        if addtl_auth_principals:
+            for arn in addtl_auth_principals:
+                # Create a patch object to add into
+                newAuthZScript=f'''ROLE="    - rolearn: {arn}\\n      username: emr-containers\\n      groups:\\n        - system:masters"
+                kubectl get -n kube-system configmap/aws-auth -o yaml | awk "/mapRoles: \|/{{print;print \\"$ROLE\\";next}}1" > /tmp/aws-auth-patch.yml
+                kubectl patch configmap/aws-auth -n kube-system --patch "$(cat /tmp/aws-auth-patch.yml)"
+                '''
+
+                newAuthZScriptProc = subprocess.run(newAuthZScript, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+                print(newAuthZScriptProc.stdout.decode('utf-8'))
 
         '''
         Send a call into plugins.ECEFalco
         '''
         if falco_bool == 'True':
             FalcoSetup.falco_initialization(
-                cluster_name=cluster_name, 
+                cluster_name=clusterName, 
                 falco_mode='Create',
                 falco_sidekick_destination_type=falco_sidekick_destination_type, 
                 falco_sidekick_destination=falco_sidekick_destination,
@@ -1290,7 +1313,7 @@ class ClusterManager():
         '''
         if datadog_bool == 'True':
             DatadogSetup.initialization(
-                cluster_name=cluster_name, 
+                cluster_name=clusterName, 
                 datadog_mode='Create',
                 datadog_api_key=datadog_api_key
             )

--- a/README.md
+++ b/README.md
@@ -12,8 +12,11 @@ At a high-level ECE...
 
 - Supports the full lifecycle of EKS management: Creation, Deletion, Rollbacks, and Updates
 - Bootstraps Nodegroups based on IMDSv2 and Custom AMIs (**Currently supports Amazon Linux 2 & Ubuntu 20.04LTS Arm64 & Amd64**)
+- Authorize additional IAM Principals into your Cluster
 - Will install and configure [Microsoft Defender for Endpoint](https://docs.microsoft.com/en-us/microsoft-365/security/defender-endpoint/microsoft-defender-endpoint?view=o365-worldwide) (MDE), Sysdig's [Falco](https://github.com/falcosecurity/falco) & [FalcoSidekick](https://github.com/falcosecurity/falcosidekick), and/or [Datadog](https://docs.datadoghq.com/agent/kubernetes/?tab=helm) if desired.
 - Perform Kubernetes Security Posture Management (KSPM) tasks using Aqua Security's [Trivy](https://github.com/aquasecurity/trivy) (vulnerability management) and [Kube-bench](https://github.com/aquasecurity/kube-bench) (EKS CIS Benchmarking) into a [SARIF](https://sarifweb.azurewebsites.net/) JSON Report
+
+After creating a Cluster with ECE, you are free to use your own tools such as `eksctl` or Terraform to further extend!
 
 ## Why use this over IAC :raised_eyebrow: :raised_eyebrow: ??
 
@@ -32,7 +35,7 @@ For those using the Console, APIs, CLI, or SDKs to create your Cluster - AWS doe
 | Secrets Envelope Encryption | :x: | :white_check_mark: |
 | Node Volume Encryption | :x: | :white_check_mark: |
 | Minimum Necessary Secuirty Group Permissions | :x: | :white_check_mark: |
-| Minimum Necessary IAM Role Permissions | :question: | :white_check_mark: |
+| Minimum Necessary IAM Role Permissions | :x: | :white_check_mark: |
 | KMS Key Generation | :x: | :white_check_mark: |
 | IMDSv2 on Nodes | :x: | :white_check_mark: |
 | [EDR](https://docs.microsoft.com/en-us/microsoft-365/security/defender-endpoint/microsoft-defender-endpoint?view=o365-worldwide) on Nodes | :x: | :white_check_mark: |

--- a/docs/HOWTO.md
+++ b/docs/HOWTO.md
@@ -34,9 +34,9 @@ helm version
 
 ### List all arguments
 
-```bash
+```
 python3 main.py -h
-usage: main.py [-h]
+usage: main.py [-h] [--profile PROFILE]
                [--mode {Create,Destroy,Update,Assessment,SetupFalco,RemoveFalco,SetupDatadog,RemoveDatadog}]
                [--k8s_version K8S_VERSION] [--s3_bucket_name S3_BUCKET_NAME]
                [--ebs_volume_size EBS_VOLUME_SIZE] [--ami_id AMI_ID]
@@ -53,9 +53,11 @@ usage: main.py [-h]
                [--falco_sidekick_destination FALCO_SIDEKICK_DESTINATION]
                [--ami_os {alas,ubuntu}] [--ami_architecture {amd64,arm64}]
                [--datadog {True,False}] [--datadog_api_key DATADOG_API_KEY]
+               [--addtl_auth_principals ADDTL_AUTH_PRINCIPALS [ADDTL_AUTH_PRINCIPALS ...]]
 
 optional arguments:
   -h, --help            show this help message and exit
+  --profile PROFILE     Specify Profile name if multiple profiles are used
   --mode {Create,Destroy,Update,Assessment,SetupFalco,RemoveFalco,SetupDatadog,RemoveDatadog}
                         Create, Destory or Update an existing Cluster. Updates
                         limited to K8s Version bump. Destroy attempts to
@@ -140,12 +142,24 @@ optional arguments:
                         Datadog API Key. This is used for setting up Datadog
                         with Create and SetupDatadog Modes as well as Datadog
                         integration for FalcoSidekick
+  --addtl_auth_principals ADDTL_AUTH_PRINCIPALS [ADDTL_AUTH_PRINCIPALS ...]
+                        Additional IAM Principal ARNs to authorized as
+                        system:masters
 ```
 
 ### Creating a Cluster with the minimum required arguements
 
 ```bash
 python3 main.py \
+    --subnets subnet-123 subnet-456 \
+    --vpcid vpc-123
+```
+
+### Creating a Cluster with the minimum required arguements, using another AWS CLI Profile
+
+```bash
+python3 main.py \
+    --profile dev \
     --subnets subnet-123 subnet-456 \
     --vpcid vpc-123
 ```
@@ -167,6 +181,19 @@ python3 main.py \
     --subnets subnet-123 subnet-456 \
     --vpcid vpc-123 \
     --additional_ports 80 1541 8001
+```
+
+### Adding additional IAM Principals into your Cluster
+
+```bash
+sudo apt install -y jq
+AWS_ACCOUNT=$(aws sts get-caller-identity | jq -r '.Account')
+ROLE_NAME_ONE='<some_role_name>'
+ROLE_NAME_TWO='<some_role_name>'
+python3 main.py \
+    --subnets subnet-123 subnet-456 \
+    --vpcid vpc-123
+    --addtl_auth_principals arn:aws:iam::$AWS_ACCOUNT:role/$ROLE_NAME_ONE arn:aws:iam::$AWS_ACCOUNT:role/$ROLE_NAME_TWO
 ```
 
 ### Creating a Cluster with Falco pre-installed

--- a/main.py
+++ b/main.py
@@ -137,7 +137,8 @@ def create_preflight_check():
         ami_os=amiOs,
         ami_architecture=amiArchitecture,
         datadog_api_key=datadogApiKey,
-        datadog_bool=datadogBool
+        datadog_bool=datadogBool,
+        addtl_auth_principals=additionalAuthZPrincipals
     )
 
     stay_dangerous()
@@ -332,6 +333,7 @@ if __name__ == "__main__":
     --ami_architecture | ami_architecture
     --datadog | datadog_bool
     --datadog_api_key | datadog_api_key
+    --addtl_auth_principals | addtl_auth_principals
     '''
     parser = argparse.ArgumentParser()
 
@@ -512,6 +514,14 @@ if __name__ == "__main__":
         required=False,
         default=None
     )
+    # addtl_auth_principals
+    # for help https://www.kite.com/python/answers/how-to-pass-a-list-as-an-argument-using-argparse-in-python
+    parser.add_argument(
+        '--addtl_auth_principals',
+        nargs='+',
+        help='Additional IAM Principal ARNs to authorized as system:masters',
+        required=False
+    )
 
     args = parser.parse_args()
     # Set Boto3 Profile if set
@@ -541,6 +551,7 @@ if __name__ == "__main__":
     amiArchitecture = args.ami_architecture
     datadogBool = args.datadog
     datadogApiKey = args.datadog_api_key
+    additionalAuthZPrincipals = args.addtl_auth_principals
 
     # This calls the creation function to create all needed IAM policies, roles and EC2/EKS infrastructure
     # will check if some infrastructure exists first to avoid needless exit later

--- a/main.py
+++ b/main.py
@@ -519,7 +519,7 @@ if __name__ == "__main__":
     parser.add_argument(
         '--addtl_auth_principals',
         nargs='+',
-        help='Additional IAM Principal ARNs to authorized as system:masters',
+        help='Additional IAM Role ARNs to authorized as system:masters',
         required=False
     )
 

--- a/main.py
+++ b/main.py
@@ -308,6 +308,7 @@ if __name__ == "__main__":
     # Feed all of the arguments 
     '''
     >> argparse argument | **kwargs <<
+    --profile | profile
     --mode | mode
     --k8s_version | kubernetes_version
     --s3_bucket_name | bucket_name
@@ -333,6 +334,14 @@ if __name__ == "__main__":
     --datadog_api_key | datadog_api_key
     '''
     parser = argparse.ArgumentParser()
+
+    # --profile
+    parser.add_argument(
+        '--profile',
+        help='Specify Profile name if multiple profiles are used',
+        required=False,
+        default=[]
+    )
     # --mode
     parser.add_argument(
         '--mode',
@@ -505,6 +514,10 @@ if __name__ == "__main__":
     )
 
     args = parser.parse_args()
+    # Set Boto3 Profile if set
+    if args.profile:
+        boto3.setup_default_session(profile_name=args.profile)
+
     # Parse all arguments to be passed to various functions
     mode = args.mode
     k8sVersion = args.k8s_version


### PR DESCRIPTION
Added the following functionality:
- Add missing K8s Tag for security group ownership into Security Group
- Add an argument to specify and set a different AWS CLI Profile Name
- Add mechanism to authorize additional IAM ARNs into the `system:masters` group using `--patch` argument
- Documentation updates

Related to Issues: #1 