### PR TITLE
SLR Creation, KMS Improvements, Trivy v0.24

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ For those using Infrastructure-as-Code (IAC) such as AWS CloudFormation and Hash
 
 ## FAQ :relieved: :relieved: ??
 
-[Read the FAQ here](./docs/HOWTO.md)
+[Read the FAQ here](./docs/FAQ.md)
 
 ## How can I contribute :arrow_upper_right: :arrow_upper_right: ??
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,14 @@ At a high-level ECE...
 
 After creating a Cluster with ECE, you are free to use your own tools such as `eksctl` or Terraform to further extend!
 
+It is very easy to get started, just provide a VPC ID and *two* matching private Subnet IDs
+
+```bash
+python3 main.py \
+    --subnets subnet-123 subnet-456 \
+    --vpcid vpc-123
+```
+
 ## Why use this over IAC :raised_eyebrow: :raised_eyebrow: ??
 
 tl;dr = ECE will create a secure cluster the first time, every time, and support the security of your clusters throughout their lifetime better than AWS' own defaults.
@@ -71,4 +79,4 @@ For more information, contact us at support@lightspin.io.
 
 ## License :eight_spoked_asterisk: :eight_spoked_asterisk:
 
-This repository is available under the [Apache License 2.0](https://github.com/lightspin-tech/red-kube/blob/main/LICENSE).
+This repository is available under the [Apache License 2.0](https://github.com/lightspin-tech/eks-creation-engine/blob/main/LICENSE).

--- a/README.md
+++ b/README.md
@@ -51,6 +51,10 @@ For those using Infrastructure-as-Code (IAC) such as AWS CloudFormation and Hash
 
 [Read the Docs here](./docs/HOWTO.md)
 
+## FAQ :relieved: :relieved: ??
+
+[Read the FAQ here](./docs/HOWTO.md)
+
 ## How can I contribute :arrow_upper_right: :arrow_upper_right: ??
 
 We are happy to take contributions from anywhere that will help expand this project. Some things that immediately come to mind...

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # Lightspin EKS Creation Engine
 
-![Known Vulnerabilities](https://snyk.io/test/github/jonrau-lightspin/eks-creation-engine/badge.svg)
-
 The Amazon Elastic Kubernetes Service (EKS) Creation Engine (ECE) is a Python command-line program created by the Lightspin Office of the CISO to facilitate the creation and enablement of secure EKS Clusters, optionally further assured with continual Kubernetes Security Posture Management (KSPM), Runtime Protection, and Application Performance Monitoring (APM) capabilities.
 
 ## What is this :eyes: :eyes: ?? 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -97,3 +97,11 @@ Yes. Upon creation of your Cluster, the AWS CLI command `aws eks update-kubeconf
 ### 6 - Will using ECE send any data to Lightspin?
 
 No! ECE is available freely under Apache-2.0 and will not "phone home" or send any data back to us.
+
+## Contact Us :telephone_receiver: :telephone_receiver:
+
+For more information, contact us at support@lightspin.io.
+
+## License :eight_spoked_asterisk: :eight_spoked_asterisk:
+
+This repository is available under the [Apache License 2.0](https://github.com/lightspin-tech/eks-creation-engine/blob/main/LICENSE).

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -11,6 +11,7 @@
             "Effect": "Allow",
             "Action": [
                 "iam:UpdateAssumeRolePolicy",
+                "iam:CreateServiceLinkedRole",
                 "ec2:AuthorizeSecurityGroupIngress",
                 "eks:ListTagsForResource",
                 "iam:ListRoleTags",
@@ -77,6 +78,22 @@
 }
 ```
 
-### 2 - 
+### 2 - Can I manage State with ECE?
 
-### 3 -
+No, not at this time. There is no inherent state concept nor drift detection in ECE.
+
+### 3 - Can I interact with my EKS Clusters with tools other than ECE?
+
+Yes! You can continue to use `ekstcl`, `boto3`, the AWS CLI and other methods to interact with your EKS Clusters. This may be required for the build out of additional post-hoc infrastructure such as adding Nodegroups or increasing the Nodecount.
+
+### 4 - Can I authorized other IAM Users or Roles? Such as a federate IAM Role or otherwise into the ClusteR?
+
+Yes! Use the `--addtl_auth_principals` argument and provide a comma-seperated list of IAM Principal ARNs (Roles & Users) to add to the `system:masters` group within your `kube-config`.
+
+### 5 - Will my `kubectl` context be changed?
+
+Yes. Upon creation of your Cluster, the AWS CLI command `aws eks update-kubeconfig --region $AWS_REGION --name $CLUSTER_NAME` is used to change your `kubectl` context for your newly created Cluster. To switch between different EKS Clusters, created by ECE or otherwise, use the command `kubectl config get-contexts` to see available contexts and finally use `kubectl config use-context $CONTEXT_NAME` to change your context with `kubectl` directly.
+
+### 6 - Will using ECE send any data to Lightspin?
+
+No! ECE is available freely under Apache-2.0 and will not "phone home" or send any data back to us.

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -86,7 +86,7 @@ No, not at this time. There is no inherent state concept nor drift detection in 
 
 Yes! You can continue to use `ekstcl`, `boto3`, the AWS CLI and other methods to interact with your EKS Clusters. This may be required for the build out of additional post-hoc infrastructure such as adding Nodegroups or increasing the Nodecount.
 
-### 4 - Can I authorized other IAM Users or Roles? Such as a federate IAM Role or otherwise into the ClusteR?
+### 4 - Can I authorized other IAM Users or Roles? Such as a federate IAM Role or otherwise into the Cluster?
 
 Yes! Use the `--addtl_auth_principals` argument and provide a comma-seperated list of IAM Principal ARNs (Roles & Users) to add to the `system:masters` group within your `kube-config`.
 

--- a/docs/HOWTO.md
+++ b/docs/HOWTO.md
@@ -5,7 +5,7 @@
 - [Installing Dependencies](#install-dependencies)
 - [IAM Permissions](#ensure-you-have-the-necessary-iam-permissions)
 - [Install Kubectl](#install-kubectl-example-shown-for-ubuntu-refer-here-for-other-os)
-- [Install Helm](#install-helm-example-shown-for-ubuntu-refer-herehttpshelmshdocsintroinstall-for-other-os)
+- [Install Helm](#install-helm-example-shown-for-ubuntu-refer-here-for-other-os)
 - [Available Arguments](#list-all-arguments)
 - [Creating a Cluster - Basic](#creating-a-cluster-with-the-minimum-required-arguements)
 - [Creating a Cluster - Use AWS CLI Profile](#creating-a-cluster-with-the-minimum-required-arguements-using-another-aws-cli-profile)
@@ -24,6 +24,8 @@
 ### Install dependencies
 
 ```bash
+git clone https://github.com/lightspin-tech/eks-creation-engine.git
+cd eks-creation-engine
 pip3 install -r requirements.txt
 ```
 
@@ -338,3 +340,11 @@ python3 main.py \
     --datadog_api_key $DATADOG_API_KEY \
     --cluster_name $CLUSTER_NAME
 ```
+
+## Contact Us :telephone_receiver: :telephone_receiver:
+
+For more information, contact us at support@lightspin.io.
+
+## License :eight_spoked_asterisk: :eight_spoked_asterisk:
+
+This repository is available under the [Apache License 2.0](https://github.com/lightspin-tech/eks-creation-engine/blob/main/LICENSE).

--- a/docs/HOWTO.md
+++ b/docs/HOWTO.md
@@ -1,5 +1,9 @@
 # Lightspin EKS Creation Engine - How to Use
 
+### Table of Contents
+
+- [Installing Dependencies](#install-dependencies)
+
 ### Install dependencies
 
 ```bash

--- a/docs/HOWTO.md
+++ b/docs/HOWTO.md
@@ -16,8 +16,10 @@
 - [Creating a Cluster with Falco - custom destination](#creating-a-cluster-with-falco-pre-installed-that-sends-alerts-to-slack)
 - [Creating a cluster with Microsoft Defender for Endpoint](#creating-a-cluster-with-microsoft-defender-for-endpoint-mde-installed-on-eks-nodes)
 - [Deleting a Cluster](#destroying-a-cluster-created-by-eks-creation-engine-ece)
-- [Updating K8s Version](#update-the-kubernetes-version-of-a-cluster-created-by-eks-creation-engine-ece)
+- [Updating K8s Version](#update-the-kubernetes-version-of-an-eks-cluster)
 - [Conduct a Security Assessment against EKS](#conduct-a-security-assessment-against-an-eks-cluster)
+- [Install Falco on existing Clusters](#install-and-configure-falco-on-an-existing-cluster)
+- [Install Datadog on existing Clusters](#install-and-configure-datadog-on-an-existing-cluster)
 
 ### Install dependencies
 
@@ -275,9 +277,9 @@ python3 main.py \
     --launch_template_name $LAUNCH_TEMPLATE_NAME
 ```
 
-### Update the Kubernetes version of am EKS cluster
+### Update the Kubernetes version of an EKS cluster
 
-**Note:** You can install Falco on ***any*** EKS Cluster, created by ECE or ohterwise, using the `kubectl config use-context <CONTEXT-NAME>` command
+**Note:** You can install Falco on ***any*** EKS Cluster, created by ECE or otherwise, using the `kubectl config use-context <CONTEXT-NAME>` command
 
 ```bash
 python3 main.py \
@@ -289,7 +291,7 @@ python3 main.py \
 
 ### Conduct a security assessment against an EKS cluster
 
-**Note:** You can run the Security Assessment against ***any*** EKS Cluster, created by ECE or ohterwise, using the `kubectl config use-context <CONTEXT-NAME>` command
+**Note:** You can run the Security Assessment against ***any*** EKS Cluster, created by ECE or otherwise, using the `kubectl config use-context <CONTEXT-NAME>` command
 
 ```bash
 python3 main.py \
@@ -299,7 +301,7 @@ python3 main.py \
 
 ### Install and configure Falco on an existing cluster
 
-**Note:** You can install Falco on ***any*** EKS Cluster, created by ECE or ohterwise, using the `kubectl config use-context <CONTEXT-NAME>` command
+**Note:** You can install Falco on ***any*** EKS Cluster, created by ECE or otherwise, using the `kubectl config use-context <CONTEXT-NAME>` command
 
 ```bash
 SLACK_WEBHOOK="https://hooks.slack.com/services/XXXX"
@@ -312,7 +314,7 @@ python3 main.py \
 
 ### Install and configure Datadog on an existing cluster
 
-**Note:** You can install Datadog on ***any*** EKS Cluster, created by ECE or ohterwise, using the `kubectl config use-context <CONTEXT-NAME>` command
+**Note:** You can install Datadog on ***any*** EKS Cluster, created by ECE or otherwise, using the `kubectl config use-context <CONTEXT-NAME>` command
 
 - Create (or locate) your Datadog API Key and place it in a secure location such as AWS Systems Manager (SSM) Parameter Store or Hashicorp Vault (*example shown for AWS SSM*)
 

--- a/docs/HOWTO.md
+++ b/docs/HOWTO.md
@@ -3,6 +3,21 @@
 ### Table of Contents
 
 - [Installing Dependencies](#install-dependencies)
+- [IAM Permissions](#ensure-you-have-the-necessary-iam-permissions)
+- [Install Kubectl](#install-kubectl-example-shown-for-ubuntu-refer-here-for-other-os)
+- [Install Helm](#install-helm-example-shown-for-ubuntu-refer-herehttpshelmshdocsintroinstall-for-other-os)
+- [Available Arguments](#list-all-arguments)
+- [Creating a Cluster - Basic](#creating-a-cluster-with-the-minimum-required-arguements)
+- [Creating a Cluster - Use AWS CLI Profile](#creating-a-cluster-with-the-minimum-required-arguements-using-another-aws-cli-profile)
+- [Creating a Cluster - ARM64 Amazon Linux 2](#creating-a-cluster-with-the-minimum-required-arguements-using-amazon-linux-2-arm64-nodes)
+- [Adding additional ports to EKS Security Groups](#creating-a-cluster-with-additional-ports-authorized-on-eks-security-groups)
+- [Adding additional IAM Principals to EKS](#adding-additional-iam-principals-into-your-cluster)
+- [Creating a Cluster with Falco](#creating-a-cluster-with-falco-pre-installed)
+- [Creating a Cluster with Falco - custom destination](#creating-a-cluster-with-falco-pre-installed-that-sends-alerts-to-slack)
+- [Creating a cluster with Microsoft Defender for Endpoint](#creating-a-cluster-with-microsoft-defender-for-endpoint-mde-installed-on-eks-nodes)
+- [Deleting a Cluster](#destroying-a-cluster-created-by-eks-creation-engine-ece)
+- [Updating K8s Version](#update-the-kubernetes-version-of-a-cluster-created-by-eks-creation-engine-ece)
+- [Conduct a Security Assessment against EKS](#conduct-a-security-assessment-against-an-eks-cluster)
 
 ### Install dependencies
 
@@ -260,7 +275,9 @@ python3 main.py \
     --launch_template_name $LAUNCH_TEMPLATE_NAME
 ```
 
-### Update the Kubernetes version of a cluster created by EKS Creation Engine (ECE)
+### Update the Kubernetes version of am EKS cluster
+
+**Note:** You can install Falco on ***any*** EKS Cluster, created by ECE or ohterwise, using the `kubectl config use-context <CONTEXT-NAME>` command
 
 ```bash
 python3 main.py \
@@ -272,6 +289,8 @@ python3 main.py \
 
 ### Conduct a security assessment against an EKS cluster
 
+**Note:** You can run the Security Assessment against ***any*** EKS Cluster, created by ECE or ohterwise, using the `kubectl config use-context <CONTEXT-NAME>` command
+
 ```bash
 python3 main.py \
     --mode Assessment \
@@ -279,6 +298,8 @@ python3 main.py \
 ```
 
 ### Install and configure Falco on an existing cluster
+
+**Note:** You can install Falco on ***any*** EKS Cluster, created by ECE or ohterwise, using the `kubectl config use-context <CONTEXT-NAME>` command
 
 ```bash
 SLACK_WEBHOOK="https://hooks.slack.com/services/XXXX"
@@ -290,6 +311,8 @@ python3 main.py \
 ```
 
 ### Install and configure Datadog on an existing cluster
+
+**Note:** You can install Datadog on ***any*** EKS Cluster, created by ECE or ohterwise, using the `kubectl config use-context <CONTEXT-NAME>` command
 
 - Create (or locate) your Datadog API Key and place it in a secure location such as AWS Systems Manager (SSM) Parameter Store or Hashicorp Vault (*example shown for AWS SSM*)
 

--- a/main.py
+++ b/main.py
@@ -18,6 +18,7 @@
 #specific language governing permissions and limitations
 #under the License.
 
+import json
 import sys
 import re
 import boto3
@@ -113,6 +114,43 @@ def create_preflight_check():
         if datadogApiKey == None:
             print(f'Datadog setup was specified but a Datadog API was not provided. Please provide a valid API key and try again.')
             sys.exit(2)
+
+    # Print out creation specification - in the future this will be a "state file" for the cluster
+    specDict = {
+        'K8sVersion': k8sVersion,
+        'S3BucketName': bucketName,
+        'EBSVolumeSize': ebsVolumeSize,
+        'AmiId': amiId,
+        'InstanceType': instanceType,
+        'ClusterName': clusterName,
+        'ClusterRoleName': clusterRoleName,
+        'NodegroupName': nodegroupName,
+        'NodegroupRoleName': nodegroupRoleName,
+        'LaunchTemplateName': launchTemplateName,
+        'VpcId': vpcId,
+        'SubnetIds': subnetIds,
+        'NodeCount': eksNodeCount,
+        'MDEOnNodes?': installMdeOnNodes,
+        'AdditionalPorts': additionalPorts,
+        'InstallFalco?': falcoBool,
+        'FalcoDestinationType': falcoDestType,
+        'FalcoDestination': falcoDest,
+        'AmiOperatingSystem': amiOs,
+        'AmiArhcitecture': amiArchitecture,
+        'DatadogApiKey': datadogApiKey,
+        'InstallDatadog?': datadogBool,
+        'AdditionalAuthorizedPrincipals': additionalAuthZPrincipals
+    }
+
+    print(f'The following attributes are set for your EKS Cluster')
+    print(
+        json.dumps(
+            specDict,
+            indent=4
+        )
+    )
+    # TODO: Save state?
+    del specDict
 
     # Call the `builder` function
     ClusterManager.builder(

--- a/main.py
+++ b/main.py
@@ -197,9 +197,9 @@ def assessment_preflight_check():
     subProc = subprocess.run(wgetCommand, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     print(subProc.stderr.decode('utf-8'))
 
-    print(f'Installing Trivy from source script')
-    # TODO: Continual updates of Trivy version https://aquasecurity.github.io/trivy/v0.22.0/getting-started/installation/#install-script
-    trivyCmd = 'curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sudo sh -s -- -b /usr/local/bin v0.22.0'
+    print(f'Installing Trivy from source script for v0.24')
+    # TODO: Continual updates of Trivy version https://aquasecurity.github.io/trivy
+    trivyCmd = 'curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sudo sh -s -- -b /usr/local/bin v0.24.0'
     trivyProc = subprocess.run(trivyCmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     print(trivyProc.stdout.decode('utf-8'))
 


### PR DESCRIPTION
**Changes**
- Add the ability to create the `autoscaling.amazonaws.com` Service-linked Role (SLR) if it did not exist, which prevents a KMS error #4 
- Version bumped Trivy to v0.24 from v0.22 to support native SARIF output
- Updated Trivy SARIF creation and parsing
- Added the ability to add additional authorized principals to KMS Policy; prevent EKS Envelope Encryption & Volume Encryption errors
- **Creation** events will now output the full specification, including (hidden to the user unless they read the docs) settings. This will be used for Statefile outputs...in the future
- Documentation updates from grammar, TOCs, and expanded FAQ
- Updated License document that pointed to `Red-kube`