### PR TITLE
Update Trivy, K8s Versions & Logging Config

### DIFF
--- a/docs/HOWTO.md
+++ b/docs/HOWTO.md
@@ -77,6 +77,7 @@ usage: main.py [-h] [--profile PROFILE]
                [--ami_os {alas,ubuntu}] [--ami_architecture {amd64,arm64}]
                [--datadog {True,False}] [--datadog_api_key DATADOG_API_KEY]
                [--addtl_auth_principals ADDTL_AUTH_PRINCIPALS [ADDTL_AUTH_PRINCIPALS ...]]
+               [--logging_types LOGGING_TYPES [LOGGING_TYPES ...]]
 
 optional arguments:
   -h, --help            show this help message and exit
@@ -168,6 +169,8 @@ optional arguments:
   --addtl_auth_principals ADDTL_AUTH_PRINCIPALS [ADDTL_AUTH_PRINCIPALS ...]
                         Additional IAM Principal ARNs to authorized as
                         system:masters
+  --logging_types LOGGING_TYPES [LOGGING_TYPES ...]
+                        Types of EKS logging to enable -- limited to "api","audit","authenticator","controllerManager","scheduler" - defaults to API logging
 ```
 
 ### Creating a Cluster with the minimum required arguements

--- a/main.py
+++ b/main.py
@@ -405,9 +405,10 @@ if __name__ == "__main__":
     # --k8s_version
     parser.add_argument(
         '--k8s_version',
-        help='Version of K8s to use for EKS - defaults to 1.21 as of 13 JAN 2022 - used for Create and Update',
+        help='Version of K8s to use for EKS - defaults to 1.24 as of 9 JAN 2023, starting with Kubernetes 1.24, new beta APIs arent enabled in clusters by default. - used for Create and Update',
         required=False,
-        default='1.21'
+        choices=['1.21', '1.22', '1.23', '1.24'],
+        default='1.24'
     )
     # --s3_bucket_name
     parser.add_argument(
@@ -569,7 +570,7 @@ if __name__ == "__main__":
     parser.add_argument(
         '--addtl_auth_principals',
         nargs='+',
-        help='Additional IAM Role ARNs to authorized as system:masters',
+        help='Additional IAM Role ARNs to authorize as system:masters',
         required=False
     )
 

--- a/main.py
+++ b/main.py
@@ -588,7 +588,7 @@ if __name__ == "__main__":
         '--logging_types',
         nargs='+',
         help='Types of EKS logging to enable -- limited to "api","audit","authenticator","controllerManager","scheduler" - defaults to API logging',
-        required=False
+        required=False,
         default=['api']
     )
 

--- a/main.py
+++ b/main.py
@@ -142,15 +142,28 @@ def create_preflight_check():
         'AdditionalAuthorizedPrincipals': additionalAuthZPrincipals
     }
 
-    print(f'The following attributes are set for your EKS Cluster')
+    # Create title for State file
+    statefileName = f'./{clusterName}_ECE_Statefile.json'
+
+    print(f'The following attributes are set for your EKS Cluster. Saving configuration to file as {statefileName}.')
     print(
         json.dumps(
             specDict,
-            indent=4
+            indent=2
         )
     )
-    # TODO: Save state?
+
+    # TODO: Actually do something with this state file...?
+    with open(statefileName, 'w') as jsonfile:
+        json.dump(
+            specDict,
+            jsonfile,
+            indent=2,
+            default=str
+        )
+
     del specDict
+    del jsonfile
 
     # Call the `builder` function
     ClusterManager.builder(
@@ -235,9 +248,8 @@ def assessment_preflight_check():
     subProc = subprocess.run(wgetCommand, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     print(subProc.stderr.decode('utf-8'))
 
-    print(f'Installing Trivy from source script for v0.24')
-    # TODO: Continual updates of Trivy version https://aquasecurity.github.io/trivy
-    trivyCmd = 'curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sudo sh -s -- -b /usr/local/bin v0.24.0'
+    print(f'Installing latest version of Trivy from source script')
+    trivyCmd = 'curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sudo sh -s -- -b /usr/local/bin latest'
     trivyProc = subprocess.run(trivyCmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     print(trivyProc.stdout.decode('utf-8'))
 


### PR DESCRIPTION
This pull request changes the default installation of Trivy to use the "latest" tag (which is oddly enough not marked in their docs as a valid option for installing with their crazy install script) which helps ensure the latest & greatest is always used and does not overwrite or conflict with locally installed versions by going backwards --- I assume if you use Trivy that you don't mind it being updated...

Also updated the K8s versions to 1.24 and added the current choices. This will require subsequent updates as AWS updates & deprecates.

Finally, added a way to specify which logging sources you want active for K8s with some funny preflight bullshit. That said, I did not want to deal with empty lists and think that is unsafe which breaks the purpose of ECE so I will default to API logging if you do not specify anything

Minor grammar & doc updates as well